### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,20 @@
       --white: #ffffff;
       --transition-speed: 0.3s;
       --box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      --footer-bg: #2b2b2b;
+      --footer-text: #ccc;
+      --section-bg: #f9f9f9;
+    }
+
+    /* Dark Theme Overrides */
+    [data-theme='dark'] {
+      --primary-color: #f1f1f1;
+      --background-color: #1a1a1a;
+      --nav-bg: rgba(34, 34, 34, 0.85);
+      --nav-text: #f1f1f1;
+      --footer-bg: #121212;
+      --footer-text: #bbb;
+      --section-bg: #2b2b2b;
     }
 
     /* Base & Reset Styles */
@@ -249,6 +263,20 @@
       transition: all var(--transition-speed); /* Animate hamburger transformation */
       border-radius: 1px;
     }
+
+    /* Dark mode toggle button */
+    .theme-toggle {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 1.2rem;
+      margin-left: 15px;
+      color: var(--nav-text);
+      transition: color var(--transition-speed);
+    }
+    .theme-toggle:hover {
+      color: var(--nav-hover);
+    }
     /* Hamburger animation to X */
      .mobile-menu-toggle.active span:nth-child(1) {
         transform: translateY(8px) rotate(45deg);
@@ -412,7 +440,7 @@
       margin-top: 30px;
     }
     #why-choose-us .benefit {
-      background: #f9f9f9; /* Slightly off-white */
+      background: var(--section-bg); /* Slightly off-white */
       padding: 25px;
       border-radius: 5px;
       box-shadow: 0 2px 5px rgba(0,0,0,0.05); /* Softer shadow */
@@ -508,7 +536,7 @@
       margin-bottom: 40px; /* More space between sub-sections */
       padding: 20px;
       border-radius: 5px;
-      background-color: #f9f9f9; /* Subtle background */
+      background-color: var(--section-bg); /* Subtle background */
     }
     #local-events h3 {
       font-size: 1.4rem; /* Larger sub-heading */
@@ -565,8 +593,8 @@
 
     /* Main Footer */
     footer {
-      background: #2b2b2b; /* Slightly lighter dark shade */
-      color: #ccc; /* Lighter grey text */
+      background: var(--footer-bg); /* Slightly lighter dark shade */
+      color: var(--footer-text); /* Lighter grey text */
       text-align: center;
       padding: 25px 20px;
       margin-top: 0; /* No margin needed after footer-cta */
@@ -833,6 +861,7 @@
       <span></span>
       <span></span>
     </button>
+    <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
   </header>
   <!-- Main Content -->
   <main>
@@ -1166,6 +1195,27 @@
       const navLinks = navMenu.querySelectorAll('a');
       const mainHeader = document.getElementById('main-header');
       const body = document.body; // Get body element
+      const themeToggle = document.getElementById('theme-toggle');
+
+      if (themeToggle) {
+        const storedTheme = localStorage.getItem('theme');
+        if (storedTheme === 'dark') {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          themeToggle.textContent = '☀️';
+        }
+        themeToggle.addEventListener('click', () => {
+          const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+          if (isDark) {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.setItem('theme', 'light');
+            themeToggle.textContent = '🌙';
+          } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            localStorage.setItem('theme', 'dark');
+            themeToggle.textContent = '☀️';
+          }
+        });
+      }
 
       mobileMenuToggle.addEventListener('click', () => {
         const isActive = navMenu.classList.toggle('active');


### PR DESCRIPTION
## Summary
- modernize by adding optional dark mode theme
- allow visitors to switch between light and dark modes
- update section and footer colors to use CSS variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ae7f3ce7c8321a2692e4095bc685e