### PR TITLE
Use Captain’s Cottage name throughout site

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
   <!-- Basic Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Charming Seaside Cottage in Scarborough | The Old Town Cottage</title>
-  <meta name="description" content="Experience The Old Town Cottage in Scarborough—a historic, pet-friendly seaside retreat blending maritime charm with modern comforts.">
-  <link rel="canonical" href="https://theoldtowncottage.com/">
+  <title>Charming Seaside Cottage in Scarborough | Captain’s Cottage</title>
+  <meta name="description" content="Experience Captain’s Cottage in Scarborough—a historic, pet-friendly seaside retreat blending maritime charm with modern comforts.">
+  <link rel="canonical" href="https://captainscottage.org/">
   <link rel="icon" href="logo.png" type="image/png">
 
   <!-- Google Tag Manager -->
@@ -19,28 +19,28 @@
   </script>
 
   <!-- Open Graph Meta Tags -->
-  <meta property="og:title" content="Charming Seaside Cottage in Scarborough | The Old Town Cottage">
+  <meta property="og:title" content="Charming Seaside Cottage in Scarborough | Captain’s Cottage">
   <meta property="og:description" content="Experience our historic seaside retreat in Scarborough, blending maritime charm with modern comforts.">
-  <meta property="og:url" content="https://theoldtowncottage.com/">
+  <meta property="og:url" content="https://captainscottage.org/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://theoldtowncottage.com/hero.jpg">
-  <meta property="og:site_name" content="The Old Town Cottage">
+  <meta property="og:image" content="https://captainscottage.org/hero.jpg">
+  <meta property="og:site_name" content="Captain’s Cottage">
   
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Charming Seaside Cottage in Scarborough | The Old Town Cottage">
+  <meta name="twitter:title" content="Charming Seaside Cottage in Scarborough | Captain’s Cottage">
   <meta name="twitter:description" content="Experience our historic seaside retreat in Scarborough, blending maritime charm with modern comforts.">
-  <meta name="twitter:image" content="https://theoldtowncottage.com/hero.jpg">
+  <meta name="twitter:image" content="https://captainscottage.org/hero.jpg">
   
   <!-- JSON-LD Structured Data for LocalBusiness -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "LodgingBusiness",
-    "name": "The Old Town Cottage",
+    "name": "Captain’s Cottage",
     "description": "A charming, historic mid-terrace cottage in Scarborough that fuses 19th-century maritime heritage with modern comforts. Recently refurbished, it offers a unique coastal getaway experience.",
-    "image": "https://theoldtowncottage.com/hero.jpg",
-    "url": "https://theoldtowncottage.com/",
+    "image": "https://captainscottage.org/hero.jpg",
+    "url": "https://captainscottage.org/",
     "telephone": "+44 1244 746200",
     "address": {
       "@type": "PostalAddress",
@@ -496,7 +496,7 @@
   <header id="main-header">
     <div class="header-left">
       <div class="logo">
-        <img src="logo.png" alt="The Old Town Cottage Logo" id="logo">
+        <img src="logo.png" alt="Captain’s Cottage Logo" id="logo">
       </div>
       <span id="nav-current-section">Home</span>
     </div>
@@ -524,10 +524,10 @@
     <section class="hero" id="home">
       <video id="hero-video" autoplay muted playsinline preload="auto" poster="hero.jpg">
         <source src="hero.mp4" type="video/mp4">
-        <img src="hero.jpg" alt="The Old Town Cottage">
+        <img src="hero.jpg" alt="Captain’s Cottage">
       </video>
       <div class="hero-content">
-        <h1>The Old Town Cottage</h1>
+        <h1>Captain’s Cottage</h1>
         <p>A historic seaside retreat in Scarborough blending maritime charm with modern comforts.</p>
         <a href="#booking" class="cta-button">Book Now</a>
       </div>
@@ -538,7 +538,7 @@
       <div class="section-container">
         <h2>Property Overview</h2>
         <p>
-          Situated at <strong>35 Longwestgate, Scarborough, North Yorkshire, YO11 1QB</strong>, The Old Town Cottage offers guests a unique blend of heritage and contemporary comfort. Originally known as Captain’s Cottage, this historic mid-terrace property has been lovingly refurbished by new owners in mid‑2024. Its rich maritime past is reflected in every detail—from period features to modern upgrades.
+          Situated at <strong>35 Longwestgate, Scarborough, North Yorkshire, YO11 1QB</strong>, Captain’s Cottage offers guests a unique blend of heritage and contemporary comfort. This historic mid-terrace property has been lovingly refurbished by new owners in mid‑2024. Its rich maritime past is reflected in every detail—from period features to modern upgrades.
         </p>
         <ul>
           <li><strong>Heritage & Refurbishment:</strong> A 19th‑century cottage revitalized with updated decor, meticulous maintenance, and enhanced guest comforts.</li>
@@ -557,10 +557,10 @@
       <div class="section-container">
         <h2>Our Story</h2>
         <p>
-          Once known as Captain’s Cottage, our property has a rich maritime heritage rooted in Scarborough’s vibrant history. Built in the 19th century, the cottage witnessed the golden era of seaside resorts. In mid‑2024, passionate new owners breathed fresh life into the property, carefully preserving its historic character while modernizing its amenities for today’s discerning traveler.
+          Captain’s Cottage has a rich maritime heritage rooted in Scarborough’s vibrant history. Built in the 19th century, the cottage witnessed the golden era of seaside resorts. In mid‑2024, passionate new owners breathed fresh life into the property, carefully preserving its historic character while modernizing its amenities for today’s discerning traveler.
         </p>
         <p>
-          Today, The Old Town Cottage stands as a testament to the timeless charm of Scarborough’s coastal legacy—where classic elegance meets contemporary comfort. Experience the fusion of history, luxury, and genuine local hospitality.
+          Today, Captain’s Cottage stands as a testament to the timeless charm of Scarborough’s coastal legacy—where classic elegance meets contemporary comfort. Experience the fusion of history, luxury, and genuine local hospitality.
         </p>
       </div>
     </section>
@@ -636,7 +636,7 @@
           <li>Complimentary parking permit for hassle-free access</li>
         </ul>
         <div class="inline-images">
-          <img src="dinningroom.jpg" alt="Outdoor decking area at The Old Town Cottage for alfresco dining" class="clickable-media" loading="lazy">
+          <img src="dinningroom.jpg" alt="Outdoor decking area at Captain’s Cottage for alfresco dining" class="clickable-media" loading="lazy">
         </div>
       </div>
     </section>
@@ -655,7 +655,7 @@
         <p>
           For direct inquiries, please contact us:
           <br><strong>Phone:</strong> +44 1244 746200
-          <br><strong>Email:</strong> <a href="mailto:info@theoldtowncottage.com">info@theoldtowncottage.com</a>
+          <br><strong>Email:</strong> <a href="mailto:info@captainscottage.org">info@captainscottage.org</a>
         </p>
       </div>
     </section>
@@ -783,16 +783,16 @@
           <!-- Video gallery item -->
           <video class="clickable-media" preload="metadata" playsinline muted poster="hero.jpg">
             <source src="hero.mp4" type="video/mp4">
-            <img src="hero.jpg" alt="The Old Town Cottage Video">
+            <img src="hero.jpg" alt="Captain’s Cottage Video">
           </video>
           <!-- Other image gallery items -->
-          <img src="entrance.jpg" alt="Gallery view of the entrance at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="livingroom.jpg" alt="Gallery view of the elegant living room at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="kitchen.jpg" alt="Gallery view of the modern kitchen at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="room1.jpg" alt="Gallery view of the spacious double bedroom at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="room2.jpg" alt="Gallery view of the twin bedroom with scenic views at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="bathroom.jpg" alt="Gallery view of the well-appointed bathroom at The Old Town Cottage" class="clickable-media" loading="lazy">
-          <img src="dinningroom.jpg" alt="Gallery view of the outdoor dining area at The Old Town Cottage" class="clickable-media" loading="lazy">
+          <img src="entrance.jpg" alt="Gallery view of the entrance at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="livingroom.jpg" alt="Gallery view of the elegant living room at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="kitchen.jpg" alt="Gallery view of the modern kitchen at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="room1.jpg" alt="Gallery view of the spacious double bedroom at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="room2.jpg" alt="Gallery view of the twin bedroom with scenic views at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="bathroom.jpg" alt="Gallery view of the well-appointed bathroom at Captain’s Cottage" class="clickable-media" loading="lazy">
+          <img src="dinningroom.jpg" alt="Gallery view of the outdoor dining area at Captain’s Cottage" class="clickable-media" loading="lazy">
         </div>
       </div>
     </section>
@@ -806,7 +806,7 @@
 
   <!-- Main Footer -->
   <footer>
-    <p>&copy; 2025 The Old Town Cottage | All Rights Reserved</p>
+    <p>&copy; 2025 Captain’s Cottage | All Rights Reserved</p>
   </footer>
 
   <!-- Lightbox Modal for Media -->


### PR DESCRIPTION
## Summary
- rename all site references from "The Old Town Cottage" to "Captain’s Cottage"
- point metadata and structured data to the new captainscottage.org domain
- update contact email and media alt text to match the new branding

## Testing
- `npx --yes htmlhint index.html`
- `php -l feedback.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4c89084688321be5eecd5c2b93812